### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">To Cuba and Back</i><br/>
-			was published in 1887 by<br/>
+			was published in 1859 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Richard_Henry_Dana_Jr.">Richard Henry Dana <abbr class="eoc">Jr.</abbr></a></p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
Changed the publication year to 1859.

- Sources: 
**Internet Archive**
https://archive.org/details/tocubabackvacati00danauoft/page/n5/mode/2up

**Google Books** (the Page Scans link on this book's Standard Ebooks page): https://www.google.com/books/edition/To_Cuba_and_Back/wEsXAAAAYAAJ

**Note**:
Regarding the Google Books link, while the particular edition linked above was published in 1887, the original publication year was 1859 (it's written on the right-hand side in 'About the Work' section).